### PR TITLE
Rename package to include user scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk-prototype-kit-step-by-step",
+  "name": "@govuk-prototype-kit/step-by-step",
   "version": "3.0.0",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
@@ -8,5 +8,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/alphagov/govuk-prototype-kit-step-by-step.git"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
We've agreed that we want to call this package `@govuk-prototype-kit/step-by-step`, with the user scope. See issue [alphagov/govuk-prototype-kit#1380] for details.

This PR renames the package for v3.

[alphagov/govuk-prototype-kit#1380]: https://github.com/alphagov/govuk-prototype-kit/issues/1380