### PR TITLE
Renumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
We've agreed that we're not going to publish branch `govuk-v27.4.0` (what was previous called `v2.0.0`), so what was previously called v3.0.0 is now v2.0.0. See comments on PR #3 for rationale.

I've already renamed the branches as appropriate, this PR just fixes the version numbering in the package manifest.