### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v2.2.1
+
+### Fixes
+
+- [#11 - Use the earliest supported version for plugin dependency](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/11)
+
 ## v2.2.0
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/step-by-step",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
### Fixes

- [#11 - Use the earliest supported version for plugin dependency](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/11)