### PR TITLE
Release 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.2.3
+
 ### Fixes
 
 - [#15 - Remove links to polyfill.io](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/15)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/step-by-step",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
## Fixes

- [#15 - Remove links to polyfill.io](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/15)