### PR TITLE
Remove instances of `$legacy` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#17 - Remove instances of `$legacy` param](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/17)
+
 ## v2.2.3
 
 ### Fixes

--- a/sass/_step-by-step-navigation-header.scss
+++ b/sass/_step-by-step-navigation-header.scss
@@ -7,7 +7,7 @@
 
   position: relative;
   padding: 10px;
-  background: govuk-colour("light-grey", $legacy: "grey-4");
+  background: govuk-colour("light-grey");
   border-bottom: solid 1px govuk-colour("blue");
   margin-top: govuk-spacing(3);
 

--- a/sass/_step-by-step-navigation.scss
+++ b/sass/_step-by-step-navigation.scss
@@ -4,7 +4,7 @@
 $stroke-width: 1px;
 $number-circle-size: 30px;
 $number-circle-size-large: 35px;
-$top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
+$top-border: solid 1px govuk-colour("mid-grey");
 
 @mixin step-nav-vertical-line($line-style: solid) {
   content: "";
@@ -12,7 +12,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: $line-style $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
+  border-left: $line-style $stroke-width govuk-colour("mid-grey");
   background: govuk-colour("white");
 }
 
@@ -264,7 +264,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
     margin-left: $number-circle-size / 4;
     width: $number-circle-size / 2;
     height: 0;
-    border-bottom: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
+    border-bottom: solid $stroke-width govuk-colour("mid-grey");
   }
 
   &:after {
@@ -323,7 +323,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .app-step-nav__circle--number {
   @include step-nav-font(16, $weight: bold, $line-height: 29px);
-  border: solid $stroke-width govuk-colour("mid-grey", $legacy: "grey-2");
+  border: solid $stroke-width govuk-colour("mid-grey");
 
   .app-step-nav--large & {
     @include step-nav-font(16, $tablet-size: 19, $weight: bold, $line-height: 29px, $tablet-line-height: 34px);
@@ -529,7 +529,7 @@ $top-border: solid 1px govuk-colour("mid-grey", $legacy: "grey-3");
 .app-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: govuk-colour("dark-grey", $legacy: "grey-1");
+  color: govuk-colour("dark-grey");
 
   &:before {
     content: " \2013\00a0"; // dash followed by &nbsp;


### PR DESCRIPTION
The `$legacy` param was deprecated in v5 and will be removed in v6