### PR TITLE
Release 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.2.4
 
 ### Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/step-by-step",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
- [#17 - Remove instances of `$legacy` param](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/17)