### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v3.0.0
+
 ### Breaking changes
 
 - [#27 - Support GOV.UK Frontend v6.0](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@govuk-prototype-kit/step-by-step",
-      "version": "2.2.4",
+      "version": "3.0.0",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govuk-prototype-kit/step-by-step",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "description": "GOV.UK Step by Step Pattern for the GOV.UK Prototype Kit",
   "author": "GOV.UK Prototype team, UK Government Digital Service",
   "license": "MIT",


### PR DESCRIPTION
## Breaking changes

- [#27 - Support GOV.UK Frontend v6.0](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/27)

## Fixes

- [#26 - Update templates to extend local template instead of prototype kit template](https://github.com/alphagov/govuk-prototype-kit-step-by-step/pull/26)